### PR TITLE
Add location field in node template

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -1,9 +1,10 @@
 ---
+# Ansible node settings
 ansible_connection: ssh
 ansible_user: ubuntu
 ansible_ssh_pass: ubuntu
-requisition: stack1-{{ env }}
-snmpd_inform_sink: 172.16.238.10
+
+# Horizon server settings
 horizon:
   resturl: http://172.16.238.11:8980/opennms/rest
   nodeapi: nodes
@@ -12,9 +13,14 @@ horizon:
   interfacesapi: interfaces
   user: admin
   password: admin
+
+# General node settings
+snmpd_inform_sink: 172.16.238.10
+requisition: stack1-{{ env }}
 services:
   ICMP:
   SNMP:
   HTTP.MyApp:
     port: "{{ http_port }}"
     path: "/"
+horizon_node_location: "Default"

--- a/ansible/host_vars/node2.yml
+++ b/ansible/host_vars/node2.yml
@@ -1,2 +1,3 @@
 ---
 ansible_host: 172.16.238.13
+horizon_node_location: "Default"

--- a/ansible/roles/horizon-provision/templates/node_xml.j2
+++ b/ansible/roles/horizon-provision/templates/node_xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- {{ ansible_managed }} -->
-<node building="{{ requisition }}" foreign-id="{{ ansible_facts['machine_id'] }}" node-label="{{ ansible_facts['hostname'] }}">
+<node location="{{ horizon_node_location }}" building="{{ requisition }}" foreign-id="{{ ansible_facts['machine_id'] }}" node-label="{{ ansible_facts['hostname'] }}">
   <interface descr="disc-if" ip-addr="{{ ansible_host }}" managed="true" status="1" snmp-primary="P"/>
   <category name="{{ env }}"/>
   <asset name="serialNumber" value="{{ ansible_facts['product_serial'] }}"/>


### PR DESCRIPTION
fix https://github.com/opennms-forge/ansible-provisioning/issues/18

Added a group_var for `location` set to `Default` and as an example a `host_var`. The `host_var` overwrites the `group_var` if set.
Also, I thought it might could make sense to group the `group_vars` variables a bit.