### PR TITLE
feat: Make poller-configuration configurable with meta-data

### DIFF
--- a/horizon/container-fs/opt/opennms-overlay/etc/poller-configuration.xml
+++ b/horizon/container-fs/opt/opennms-overlay/etc/poller-configuration.xml
@@ -2,6 +2,37 @@
    <node-outage status="on" pollAllIfNoCriticalServiceDefined="true">
       <critical-service name="ICMP"/>
    </node-outage>
+   <!--
+      This package is defined for Minion nodes. Don't alter/remove this. If minions are not getting used, it is safe to remove below pkg.
+   -->
+   <package name="Minion">
+      <filter>foreignSource == 'Minions' AND IPADDR != '0.0.0.0'</filter>
+      <rrd step="30">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="Minion-Heartbeat" interval="30000" user-defined="false" status="on">
+         <parameter key="period" value="30000"/><!-- Service interval should be same as period -->
+      </service>
+      <service name="Minion-RPC" interval="30000" user-defined="false" status="on">
+         <parameter key="ttl" value="30000"/><!-- TTL should be same as period -->
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="ds-name" value="minion-rpc"/>
+      </service>
+      <service name="JMX-Minion" interval="30000" user-defined="false" status="on">
+         <parameter key="port" value="18980"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="ds-name" value="jmx-minion"/>
+         <parameter key="use-foreign-id-as-system-id" value="true"/>
+      </service>
+      <!-- Query every 30secs always -->
+      <downtime begin="0" interval="30000"/><!-- 30s -->
+   </package>
    <package name="cassandra-via-jmx">
       <filter>IPADDR != '0.0.0.0'</filter>
       <rrd step="300">
@@ -12,7 +43,6 @@
          <rra>RRA:MIN:0.5:288:366</rra>
       </rrd>
       <service name="JMX-Cassandra" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^JMX-Cassandra.*$]]></pattern>
          <parameter key="port" value="7199"/>
          <parameter key="retry" value="2"/>
          <parameter key="timeout" value="3000"/>
@@ -30,7 +60,6 @@
          <parameter key="tests.joined" value="storage.Joined"/>
       </service>
       <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^JMX-Cassandra-Newts.*$]]></pattern>
          <parameter key="port" value="7199"/>
          <parameter key="retry" value="2"/>
          <parameter key="timeout" value="3000"/>
@@ -57,317 +86,6 @@
       <downtime begin="43200000" end="432000000" interval="600000"/><!-- 10m, 12h, 5d -->
       <downtime begin="432000000" interval="3600000"/><!-- 1h, 5d -->
    </package>
-   <package name="polling-5m">
-      <filter>IPADDR != '0.0.0.0'</filter>
-      <include-range begin="1.1.1.1" end="254.254.254.254"/>
-      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
-      <rrd step="300">
-         <rra>RRA:AVERAGE:0.5:1:2016</rra>
-         <rra>RRA:AVERAGE:0.5:12:1488</rra>
-         <rra>RRA:AVERAGE:0.5:288:366</rra>
-         <rra>RRA:MAX:0.5:288:366</rra>
-         <rra>RRA:MIN:0.5:288:366</rra>
-      </rrd>
-      <service name="ICMP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^ICMP.*$]]></pattern>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="icmp"/>
-         <parameter key="ds-name" value="icmp"/>
-      </service>
-      <service name="DNS" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^DNS.*$]]></pattern>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="5000"/>
-         <parameter key="port" value="53"/>
-         <parameter key="lookup" value="localhost"/>
-         <parameter key="fatal-response-codes" value="2,3,5"/><!-- ServFail, NXDomain, Refused -->
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="dns"/>
-         <parameter key="ds-name" value="dns"/>
-      </service>
-      <service name="Elasticsearch" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^Elasticsearch.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="9200"/>
-         <parameter key="url" value="/_cluster/stats"/>
-         <parameter key="response" value="200-202,299"/>
-         <parameter key="response-text" value="~.*status.:.green.*"/>
-      </service>
-      <service name="SMTP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^SMTP.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="25"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="smtp"/>
-         <parameter key="ds-name" value="smtp"/>
-      </service>
-      <service name="FTP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^FTP.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="21"/>
-         <parameter key="userid" value=""/>
-         <parameter key="password" value=""/>
-      </service>
-      <service name="SNMP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^SNMP.*$]]></pattern>
-         <parameter key="oid" value=".1.3.6.1.2.1.1.2.0"/>
-      </service>
-      <service name="HTTP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^HTTP..*$]]></pattern>
-         <parameter key="retry" value="${requisition:retry|1}"/>
-         <parameter key="timeout" value="${requisition:timeout|3000}"/>
-         <parameter key="port" value="${requisition:port|80}"/>
-         <parameter key="url" value="${requisition:path|/}"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="http"/>
-         <parameter key="ds-name" value="http"/>
-      </service>
-      <service name="HTTPS" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^HTTPS..*$]]></pattern>
-         <parameter key="retry" value="${requisition:retry|1}"/>
-         <parameter key="timeout" value="${requisition:timeout|3000}"/>
-         <parameter key="port" value="${requisition:port|443}"/>
-         <parameter key="url" value="${requisition:path|/}"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="https"/>
-         <parameter key="ds-name" value="https"/>
-      </service>
-      <service name="HypericAgent" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^HypericAgent.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="2200"/>
-         <parameter key="port" value="2144"/>
-      </service>
-      <service name="HypericHQ" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^HypericHQ.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="hyperic-hq"/>
-         <parameter key="ds-name" value="hyperic-hq"/>
-         <parameter key="page-sequence">
-            <page-sequence xmlns="">
-               <page disable-ssl-verification="true" host="${ipaddr}" http-version="1.1" method="GET" path="/Login.do" port="7080" response-range="100-399" scheme="http" successMatch="(HQ Login)|(Sign in to Hyperic HQ)" xmlns=""/>
-               <page disable-ssl-verification="true" failureMatch="(?s)(The username or password provided does not match our records)|(You are not signed in)" failureMessage="HQ Login in Failed" host="${ipaddr}" http-version="1.1" method="POST" path="/j_security_check.do" port="7080" response-range="100-399" scheme="http" successMatch="HQ Dashboard" xmlns="">
-                  <parameter key="j_username" value="hqadmin" xmlns=""/>
-                  <parameter key="j_password" value="hqadmin" xmlns=""/>
-               </page>
-               <page disable-ssl-verification="true" host="${ipaddr}" http-version="1.1" method="GET" path="/Logout.do" port="7080" response-range="100-399" scheme="http" successMatch="HQ Login" xmlns=""/>
-            </page-sequence>
-         </parameter>
-      </service>
-      <service name="MySQL" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^MySQL.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="3306"/>
-         <parameter key="banner" value="*"/>
-      </service>
-      <service name="SQLServer" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^SQLServer.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="1433"/>
-         <parameter key="banner" value="*"/>
-      </service>
-      <service name="Oracle" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^Oracle.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="1521"/>
-         <parameter key="banner" value="*"/>
-      </service>
-      <service name="Postgres" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^Postgres.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="banner" value="*"/>
-         <parameter key="port" value="5432"/>
-         <parameter key="timeout" value="3000"/>
-      </service>
-      <service name="SSH" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^SSH.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="banner" value="SSH"/>
-         <parameter key="port" value="22"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="ssh"/>
-         <parameter key="ds-name" value="ssh"/>
-      </service>
-      <service name="IMAP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^IMAP.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="port" value="143"/>
-         <parameter key="timeout" value="3000"/>
-      </service>
-      <service name="POP3" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^POP3.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="port" value="110"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="pop3"/>
-         <parameter key="ds-name" value="pop3"/>
-      </service>
-      <service name="NRPE" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^NRPE.*$]]></pattern>
-         <parameter key="retry" value="3"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="5666"/>
-         <parameter key="command" value="_NRPE_CHECK"/>
-         <parameter key="padding" value="2"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="ds-name" value="nrpe"/>
-      </service>
-      <service name="NRPE-NoSSL" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^NRPE-NoSSL.*$]]></pattern>
-         <parameter key="retry" value="3"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="port" value="5666"/>
-         <parameter key="command" value="_NRPE_CHECK"/>
-         <parameter key="usessl" value="false"/>
-         <parameter key="padding" value="2"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="ds-name" value="nrpe"/>
-      </service>
-      <service name="Windows-Task-Scheduler" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^Windows-Task-Scheduler.*$]]></pattern>
-         <parameter key="service-name" value="Task Scheduler"/>
-      </service>
-      <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^OpenNMS-JVM.*$]]></pattern>
-         <parameter key="port" value="18980"/>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-      </service>
-      <service name="JMX-Kafka" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^JMX-Kafka.*$]]></pattern>
-         <parameter key="port" value="9999"/>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="factory" value="PASSWORD_CLEAR"/>
-         <parameter key="username" value="admin"/>
-         <parameter key="password" value="admin"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-      </service>
-      <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^VMwareCim-HostSystem.*$]]></pattern>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="ignoreStandBy" value="false"/>
-      </service>
-      <service name="VMware-ManagedEntity" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^VMware-ManagedEntity.*$]]></pattern>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="ignoreStandBy" value="false"/>
-         <parameter key="reportAlarms" value=""/>
-      </service>
-      <service name="MS-RDP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^MS-RDP.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="banner" value="*"/>
-         <parameter key="port" value="3389"/>
-         <parameter key="timeout" value="3000"/>
-      </service>
-      <service name="ActiveMQ" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^ActiveMQ.*$]]></pattern>
-         <parameter key="retry" value="1" />
-         <parameter key="timeout" value="3000" />
-         <parameter key="brokerURL" value="tcp://localhost:61616" />
-      </service>
-      <service name="MinaSSH" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^MinaSSH.*$]]></pattern>
-         <parameter key="retry" value="1"/>
-         <parameter key="port" value="22"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="minassh"/>
-         <parameter key="ds-name" value="minassh"/>
-         <parameter key="username" value="admin"/>
-         <parameter key="password" value="admin"/>
-      </service>
-      <downtime begin="0" end="300000" interval="30000"/><!-- 30s, 0, 5m -->
-      <downtime begin="300000" end="43200000" interval="300000"/><!-- 5m, 5m, 12h -->
-      <downtime begin="43200000" end="432000000" interval="600000"/><!-- 10m, 12h, 5d -->
-      <downtime begin="432000000" interval="3600000"/><!-- 1h, 5d -->
-   </package>
-
-   <!--
-      This package is defined for Minion nodes. Don't alter/remove this. If minions are not getting used, it is safe to remove below pkg.
-   -->
-   <package name="Minion">
-      <filter>foreignSource == 'Minions' AND IPADDR != '0.0.0.0'</filter>
-      <rrd step="30">
-         <rra>RRA:AVERAGE:0.5:1:2016</rra>
-         <rra>RRA:AVERAGE:0.5:12:1488</rra>
-         <rra>RRA:AVERAGE:0.5:288:366</rra>
-         <rra>RRA:MAX:0.5:288:366</rra>
-         <rra>RRA:MIN:0.5:288:366</rra>
-      </rrd>
-      <service name="Minion-Heartbeat" interval="30000" user-defined="false" status="on">
-         <pattern><![CDATA[^Minion-Heartbeat.*$]]></pattern>
-         <parameter key="period" value="30000"/><!-- Service interval should be same as period -->
-      </service>
-      <service name="Minion-RPC" interval="30000" user-defined="false" status="on">
-         <pattern><![CDATA[^Minion-RPC.*$]]></pattern>
-         <parameter key="ttl" value="30000"/><!-- TTL should be same as period -->
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="ds-name" value="minion-rpc"/>
-      </service>
-      <service name="JMX-Minion" interval="30000" user-defined="false" status="on">
-         <pattern><![CDATA[^JMX-Minion.*$]]></pattern>
-         <parameter key="port" value="18980"/>
-         <parameter key="retry" value="2"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="ds-name" value="jmx-minion"/>
-         <parameter key="use-foreign-id-as-system-id" value="true"/>
-      </service>
-      <service name="SNMP" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^SNMP.*$]]></pattern>
-         <parameter key="oid" value=".1.3.6.1.2.1.1.2.0"/>
-      </service>
-      <!-- Query every 30secs always -->
-      <downtime begin="0" interval="30000"/><!-- 30s -->
-   </package>
-   <!--
-      Moved StrafePing to its own package.  This allows for more flexible configuration of which interfaces
-      will have StrafePing statistical analysis rather than being on for or off for all interfaces.  Change
-      this package's filter / ranges for directing the StrafePinger to choice interfaces.  Note: Strafing all
-      of your network interface may create high loads on the NMS file system.
-   -->
-   <package name="strafer">
-      <filter>IPADDR != '0.0.0.0'</filter>
-      <include-range begin="10.1.1.1" end="10.1.1.10"/>
-      <!-- <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" /> -->
-      <rrd step="300">
-         <rra>RRA:AVERAGE:0.5:1:2016</rra>
-         <rra>RRA:AVERAGE:0.5:12:1488</rra>
-         <rra>RRA:AVERAGE:0.5:288:366</rra>
-         <rra>RRA:MAX:0.5:288:366</rra>
-         <rra>RRA:MIN:0.5:288:366</rra>
-      </rrd>
-      <service name="StrafePing" interval="300000" user-defined="false" status="on">
-         <pattern><![CDATA[^StrafePing.*$]]></pattern>
-         <parameter key="retry" value="0"/>
-         <parameter key="timeout" value="3000"/>
-         <parameter key="ping-count" value="20"/>
-         <parameter key="failure-ping-count" value="20"/>
-         <parameter key="wait-interval" value="50"/>
-         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
-         <parameter key="rrd-base-name" value="strafeping"/>
-      </service>
-      <downtime begin="0" end="432000000" interval="300000"/><!-- 5m, 0, 5d -->
-      <downtime begin="432000000" interval="3600000"/><!-- 1h, 5d -->
-   </package>
-
    <package name="device-config">
       <filter>IPADDR != '0.0.0.0'</filter>
       <rrd step="300">
@@ -395,39 +113,252 @@
       </service>
       <downtime begin="0" interval="300000"/><!-- 300s -->
    </package>
+   <package name="opennms-builtin">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254"/>
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="18980"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+      </service>
+      <service name="JMX-Kafka" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="9999"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="factory" value="PASSWORD_CLEAR"/>
+         <parameter key="username" value="admin"/>
+         <parameter key="password" value="admin"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+      </service>
+      <downtime begin="0" end="300000" interval="30000"/><!-- 30s, 0, 5m -->
+      <downtime begin="300000" end="43200000" interval="300000"/><!-- 5m, 5m, 12h -->
+      <downtime begin="43200000" end="432000000" interval="600000"/><!-- 10m, 12h, 5d -->
+      <downtime begin="432000000" interval="3600000"/><!-- 1h, 5d -->
+   </package>
 
+   <!--
+   Moved StrafePing to its own package.  This allows for more flexible configuration of which interfaces
+   will have StrafePing statistical analysis rather than being on for or off for all interfaces.  Change
+   this package's filter / ranges for directing the StrafePinger to choice interfaces.  Note: Strafing all
+   of your network interface may create high loads on the NMS file system.
+   -->
+   <package name="strafer">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="10.1.1.1" end="10.1.1.10"/>
+      <!-- <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" /> -->
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="StrafePing" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^StrafePing.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|0}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}" />
+         <parameter key="ping-count" value="${requisition:ping-count|20}"/>
+         <parameter key="failure-ping-count" value="${requisition:failure-ping-count|20}"/>
+         <parameter key="wait-interval" value="${requisition:wait-interval|50}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="strafeping"/>
+      </service>
+      <downtime begin="0" end="432000000" interval="300000"/><!-- 5m, 0, 5d -->
+      <downtime begin="432000000" interval="3600000"/><!-- 1h, 5d -->
+   </package>
+
+   <!--
+   Customizable Service Monitoring
+   -->
+   <package name="service-tests-300s">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254"/>
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="ActiveMQ" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^ActiveMQ.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}" />
+         <parameter key="brokerURL" value="${requisition:brokerURL|tcp://localhost:61616}" />
+      </service>
+      <service name="DNS" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^DNS.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|2}"/>
+         <parameter key="timeout" value="${requisition:timeout|5000}"/>
+         <parameter key="port" value="${requisition:port|53}"/>
+         <parameter key="lookup" value="${requisition:lookup|localhost}"/>
+         <parameter key="fatal-response-codes" value="${requisition:fatal-response-codes|2,3,5}"/><!-- ServFail, NXDomain, Refused -->
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="dns"/>
+         <parameter key="ds-name" value="dns"/>
+      </service>
+      <service name="FTP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^FTP.*$]]></pattern>
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="port" value="${requisition:port|21}"/>
+         <parameter key="userid" value="${requisition:userid|}"/>
+         <parameter key="password" value="${requisition:password|}"/>
+      </service>
+      <service name="HTTP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^HTTP..*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="port" value="${requisition:port|80}"/>
+         <parameter key="url" value="${requisition:path|/}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="http"/>
+         <parameter key="ds-name" value="http"/>
+      </service>
+      <service name="HTTPS" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^HTTPS..*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="port" value="${requisition:port|443}"/>
+         <parameter key="url" value="${requisition:path|/}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="https"/>
+         <parameter key="ds-name" value="https"/>
+      </service>
+      <service name="ICMP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^ICMP.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|2}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="icmp"/>
+         <parameter key="ds-name" value="icmp"/>
+      </service>
+      <service name="IMAP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^IMAP.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="port" value="${requisition:port|143}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+      </service>
+      <service name="MinaSSH" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^MinaSSH.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="port" value="${requisition:port|22}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="minassh"/>
+         <parameter key="ds-name" value="minassh"/>
+         <parameter key="username" value="${requisition:username|admin}"/>
+         <parameter key="password" value="${requisition:password|admin}"/>
+      </service>
+      <service name="NRPE" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^NRPE.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|2}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="port" value="${requisition:port|5666}"/>
+         <parameter key="command" value="${requisition:command|_NRPE_CHECK}"/>
+         <parameter key="padding" value="${requisition:padding|2}"/>
+         <parameter key="usessl" value="${requisition:usessl|true}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="ds-name" value="nrpe"/>
+      </service>
+      <service name="POP3" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^POP3.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="port" value="${requisition:port|110}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="pop3"/>
+         <parameter key="ds-name" value="pop3"/>
+      </service>
+      <service name="SMTP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^SMTP.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="port" value="${requisition:port|25}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="smtp"/>
+         <parameter key="ds-name" value="smtp"/>
+      </service>
+      <service name="SNMP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^SNMP.*$]]></pattern>
+         <parameter key="oid" value="${requisition:oid|.1.3.6.1.2.1.1.2.0}"/>
+      </service>
+      <service name="SSH" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^SSH.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="banner" value="${requisition:banner|SSH}"/>
+         <parameter key="port" value="${requisition:port|22}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="ssh"/>
+         <parameter key="ds-name" value="ssh"/>
+      </service>
+      <service name="TCP" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^TCP.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|1}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="port" value="${requisition:port|23}"/>
+      </service>
+      <service name="VMware-ManagedEntity" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^VMware-ManagedEntity.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|2}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="ignoreStandBy" value="${requisition:ignoreStandBy|false}"/>
+         <parameter key="reportAlarms" value="${requisition:reportAlarms|}"/>
+      </service>
+      <service name="VMwareCim-HostSystem" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^VMwareCim-HostSystem.*$]]></pattern>
+         <parameter key="retry" value="${requisition:retry|2}"/>
+         <parameter key="timeout" value="${requisition:timeout|3000}"/>
+         <parameter key="ignoreStandBy" value="${requisition:ignoreStandBy|false}"/>
+      </service>
+      <service name="Windows-Task-Scheduler" interval="300000" user-defined="true" status="on">
+         <pattern><![CDATA[^Windows-Task-Scheduler.*$]]></pattern>
+         <parameter key="service-name" value="${requisition:service-name|Task Scheduler}"/>
+      </service>
+      <downtime begin="0" end="300000" interval="30000"/><!-- 30s, 0, 5m -->
+      <downtime begin="300000" end="43200000" interval="300000"/><!-- 5m, 5m, 12h -->
+      <downtime begin="43200000" end="432000000" interval="600000"/><!-- 10m, 12h, 5d -->
+      <downtime begin="432000000" interval="3600000"/><!-- 1h, 5d -->
+   </package>
+
+   <!-- Built monitors for OpenNMS -->
+   <monitor service="DeviceConfig" class-name="org.opennms.features.deviceconfig.monitors.DeviceConfigMonitor" />
    <monitor service="JMX-Cassandra" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
    <monitor service="JMX-Cassandra-Newts" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
-   <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor"/>
-   <monitor service="StrafePing" class-name="org.opennms.netmgt.poller.monitors.StrafePingMonitor"/>
-   <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor"/>
-   <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor"/>
-   <monitor service="HypericAgent" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
-   <monitor service="HypericHQ" class-name="org.opennms.netmgt.poller.monitors.PageSequenceMonitor"/>
-   <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor"/>
-   <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor"/>
-   <monitor service="Elasticsearch" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor"/>
-   <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor"/>
-   <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor"/>
-   <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
-   <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="JMX-Kafka" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
+   <monitor service="JMX-Minion" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
    <monitor service="Minion-Heartbeat" class-name="org.opennms.netmgt.poller.monitors.MinionHeartbeatMonitor"/>
    <monitor service="Minion-RPC" class-name="org.opennms.netmgt.poller.monitors.MinionRpcMonitor"/>
-   <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
-   <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
-   <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.SshMonitor"/>
-   <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor"/>
-   <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor"/>
-   <monitor service="NRPE" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor"/>
-   <monitor service="NRPE-NoSSL" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor"/>
-   <monitor service="Windows-Task-Scheduler" class-name="org.opennms.netmgt.poller.monitors.Win32ServiceMonitor"/>
    <monitor service="OpenNMS-JVM" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
-   <monitor service="JMX-Minion" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
-   <monitor service="JMX-Kafka" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
-   <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor"/>
-   <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor"/>
-   <monitor service="MS-RDP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+
+   <!-- Customizable Service Monitoring -->
    <monitor service="ActiveMQ" class-name="org.opennms.netmgt.poller.monitors.ActiveMQMonitor" />
-   <monitor service="DeviceConfig" class-name="org.opennms.features.deviceconfig.monitors.DeviceConfigMonitor" />
+   <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor"/>
+   <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor"/>
+   <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor"/>
+   <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor"/>
+   <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor"/>
+   <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor"/>
    <monitor service="MinaSSH" class-name="org.opennms.netmgt.poller.monitors.MinaSshMonitor"/>
+   <monitor service="NRPE" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor"/>
+   <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor"/>
+   <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor"/>
+   <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor"/>
+   <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.SshMonitor"/>
+   <monitor service="StrafePing" class-name="org.opennms.netmgt.poller.monitors.StrafePingMonitor"/>
+   <monitor service="TCP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor"/>
+   <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor"/>
+   <monitor service="Windows-Task-Scheduler" class-name="org.opennms.netmgt.poller.monitors.Win32ServiceMonitor"/>
 </poller-configuration>


### PR DESCRIPTION
Make all parameters configurable with meta-data and preserve default values. Remove duplicated services and use the pattern match functionality to allow users to define arbitrary services by prefixing the service name. Keep the built-in services for OpenNMS services to preserve backward compatibility.


Resolve #29 