### PR TITLE
✨ feat: Improvements about synchronising requisitions and tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,11 @@ onms_host_services:
    HTTPS: {}
 ```
 
+`skip_import` can be used to control, whether the requisition gets imported or not
 
+Example:
+
+The default is `false` to always import.
+```
+ansible-playbook -i inventory site.yml --extra-vars '{"skip_import":"true"}'
+```

--- a/ansible/01-webserver.yml
+++ b/ansible/01-webserver.yml
@@ -1,7 +1,8 @@
 ---
 # file: 01-webserver.yml
 
-- hosts: webserver
+- name: Group of web server
+  hosts: webserver
   become: true
   roles:
     - apache2

--- a/ansible/02-net-snmp.yml
+++ b/ansible/02-net-snmp.yml
@@ -1,7 +1,8 @@
 ---
 # file: 02-net-snmp.yml
 
-- hosts: all
+- name: Group of Servers with Net-SNMP agents
+  hosts: all
   become: true
   roles:
     - net-snmp

--- a/ansible/03-switches.yml
+++ b/ansible/03-switches.yml
@@ -1,7 +1,8 @@
 ---
 # file: horizon-provision.yaml
 
-- hosts: switches
+- name: Group of switches not managed with Ansible
+  hosts: switches
   gather_facts: false
   become: false
   roles:

--- a/ansible/99-horizon-provision.yml
+++ b/ansible/99-horizon-provision.yml
@@ -1,7 +1,8 @@
 ---
 # file: horizon-provision.yaml
 
-- hosts: monitoring
+- name: Group of hosts provisioned into OpenNMS Horizon
+  hosts: monitoring
   gather_facts: true
   become: true
   roles:

--- a/ansible/99-horizon-provision.yml
+++ b/ansible/99-horizon-provision.yml
@@ -6,13 +6,3 @@
   become: true
   roles:
     - horizon-provision
-  tasks:
-    - name: "Import requisitions"
-      ansible.builtin.uri:
-        url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/import?rescanExisting=true"
-        user: "{{ onms_hzn_user }}"
-        password: "{{ onms_hzn_password }}"
-        method: PUT
-        status_code: 202
-        headers:
-          Content-Type: "application/xml"

--- a/ansible/group_vars/prod/vars.yml
+++ b/ansible/group_vars/prod/vars.yml
@@ -28,7 +28,7 @@ onms_policies:
     parameters:
       foreignSource: "{{ onms_requisition_name }}"
       metadataKey: alerting_channel
-      metadataValue: "alerting-{{onms_requisition_name}}"
+      metadataValue: "alerting-{{ onms_requisition_name }}"
       matchBehavior: ANY_PARAMETER
 
 # Node MetaData in key/value pairs

--- a/ansible/roles/apache2/handlers/main.yml
+++ b/ansible/roles/apache2/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
-- name: restart apache2
-  service: name=apache2 state=restarted
+- name: Restart apache2
+  ansible.builtin.service:
+    name: apache2
+    state: restarted

--- a/ansible/roles/apache2/tasks/main.yml
+++ b/ansible/roles/apache2/tasks/main.yml
@@ -1,21 +1,25 @@
 ---
 - name: "Install Apache2"
-  apt: name=apache2 update_cache=yes state=present
+  ansible.builtin.apt:
+    name=apache2 update_cache=yes state=present
 
 - name: "Enabled mod_rewrite"
-  apache2_module: name=rewrite state=present
+  community.general.apache2_module:
+    name=rewrite state=present
   notify:
-    - restart apache2
+    - Restart apache2
 
 - name: "Apache2 listen"
-  lineinfile: dest=/etc/apache2/ports.conf regexp="^Listen.*" line="Listen {{ http_port }}" state=present
+  ansible.builtin.lineinfile:
+    dest=/etc/apache2/ports.conf regexp="^Listen.*" line="Listen {{ http_port }}" state=present
   notify:
-    - restart apache2
+    - Restart apache2
 
 - name: "Apache2 virtualhost"
-  lineinfile: dest=/etc/apache2/sites-available/000-default.conf regexp="^<VirtualHost \*:.*>" line="<VirtualHost *:{{ http_port }}>" state=present
+  ansible.builtin.lineinfile:
+    dest=/etc/apache2/sites-available/000-default.conf regexp="^<VirtualHost \*:.*>" line="<VirtualHost *:{{ http_port }}>" state=present
   notify:
-    - restart apache2
+    - Restart apache2
 
 - name: "Start service Apache2"
   ansible.builtin.service:

--- a/ansible/roles/apache2/tasks/main.yml
+++ b/ansible/roles/apache2/tasks/main.yml
@@ -1,23 +1,32 @@
 ---
 - name: "Install Apache2"
   ansible.builtin.apt:
-    name=apache2 update_cache=yes state=present
+    name: apache2
+    update_cache: true
+    state: present
 
 - name: "Enabled mod_rewrite"
   community.general.apache2_module:
-    name=rewrite state=present
+    name: rewrite
+    state: present
   notify:
     - Restart apache2
 
 - name: "Apache2 listen"
   ansible.builtin.lineinfile:
-    dest=/etc/apache2/ports.conf regexp="^Listen.*" line="Listen {{ http_port }}" state=present
+    dest: /etc/apache2/ports.conf
+    regexp: "^Listen.*"
+    line: "Listen {{ http_port }}"
+    state: present
   notify:
     - Restart apache2
 
 - name: "Apache2 virtualhost"
   ansible.builtin.lineinfile:
-    dest=/etc/apache2/sites-available/000-default.conf regexp="^<VirtualHost \*:.*>" line="<VirtualHost *:{{ http_port }}>" state=present
+    dest: /etc/apache2/sites-available/000-default.conf
+    regexp: ^<VirtualHost \*:.*>
+    line: <VirtualHost *:{{ http_port }}>
+    state: present
   notify:
     - Restart apache2
 

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -10,6 +10,8 @@
   ignore_errors: true
   no_log: true
   register: requisition_exists
+  tags:
+    - opennms-provisioning
 
 - name: "Create requisitions"
   ansible.builtin.uri:
@@ -24,6 +26,8 @@
   no_log: true
   register: requisition_created
   when: requisition_exists.failed
+  tags:
+    - opennms-provisioning
 
 - name: "Create policies and detectors for requisitions (foreign-sources)"
   ansible.builtin.uri:
@@ -38,6 +42,8 @@
   no_log: true
   register: requisition_created
   when: requisition_exists
+  tags:
+    - opennms-provisioning
 
 - name: "Verify if nodes exist in requisitions"
   ansible.builtin.uri:
@@ -51,6 +57,8 @@
   no_log: true
   register: node_exists
   when: requisition_exists
+  tags:
+    - opennms-provisioning
 
 - name: "Create nodes in requisitions"
   ansible.builtin.uri:
@@ -65,6 +73,8 @@
   no_log: false
   register: node_created
   when: node_exists.failed
+  tags:
+    - opennms-provisioning
 
 - name: "Verify if monitored services exists"
   ansible.builtin.uri:
@@ -80,6 +90,8 @@
   register: service_exists
   when: node_exists
   with_items: "{{ onms_group_services | combine(onms_host_services) }}"
+  tags:
+    - opennms-provisioning
 
 - name: "Create monitored services"
   ansible.builtin.uri:
@@ -97,7 +109,13 @@
   register: service_created
   when: service_exists.failed
   with_dict: "{{ onms_group_services | combine(onms_host_services) }}"
+  tags:
+    - opennms-provisioning
 
+# ansible_play-hosts:
+# List of hosts in the current play run, not limited by the serial. Failed/Unreachable hosts are excluded from this list.
+# With the condition inventory_hostname == ansible_play_hosts[-1] we run the task only for the last host in the current play
+# and ensures we run this task only once per group
 - name: "Import requisitions"
   ansible.builtin.uri:
     url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/import?rescanExisting=true"
@@ -109,3 +127,6 @@
       Content-Type: "application/xml"
   when:
     - skip_import | default("false") == "false"
+  tags:
+    - opennms-provisioning
+    - opennms-requisition-import

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -97,3 +97,15 @@
   register: service_created
   when: service_exists.failed
   with_dict: "{{ onms_group_services | combine(onms_host_services) }}"
+
+- name: "Import requisitions"
+  ansible.builtin.uri:
+    url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/import?rescanExisting=true"
+    user: "{{ onms_hzn_user }}"
+    password: "{{ onms_hzn_password }}"
+    method: PUT
+    status_code: 202
+    headers:
+      Content-Type: "application/xml"
+  when:
+    - skip_import | default("false") == "false"

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -126,7 +126,7 @@
     headers:
       Content-Type: "application/xml"
   when:
-    - skip_import | default("false") == "false"
+    - inventory_hostname == ansible_play_hosts[-1] and skip_import | default("false") == "false"
   tags:
     - opennms-provisioning
     - opennms-requisition-import

--- a/ansible/roles/net-snmp/handlers/main.yml
+++ b/ansible/roles/net-snmp/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart snmpd
+- name: restart snmpd
   ansible.builtin.service:
     name: snmpd
     state: restarted

--- a/ansible/roles/net-snmp/handlers/main.yml
+++ b/ansible/roles/net-snmp/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
 - name: Restart snmpd
   ansible.builtin.service:
-    name=snmpd state=restarted
+    name: snmpd
+    state: restarted

--- a/ansible/roles/net-snmp/handlers/main.yml
+++ b/ansible/roles/net-snmp/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
-- name: restart snmpd
-  service: name=snmpd state=restarted
+- name: Restart snmpd
+  ansible.builtin.service:
+    name=snmpd state=restarted

--- a/ansible/roles/net-snmp/tasks/main.yml
+++ b/ansible/roles/net-snmp/tasks/main.yml
@@ -1,46 +1,71 @@
 ---
 - name: Install snmpd packages
-  apt: name=snmpd state=present
+  ansible.builtin.apt:
+    name: snmpd
+    state: present
   tags: ['net-snmp']
 
 - name: Add the user 'snmp'
   ansible.builtin.user:
     name: snmp
 
-- name: Ensures {{ snmpd_include_dir }} dir exists
-  file: path={{ snmpd_include_dir }} state=directory mode=0640
+- name: Ensures include dir exists
+  ansible.builtin.file:
+    path: "{{ snmpd_include_dir }}"
+    state: directory
+    mode: "0640"
   tags: ['net-snmp']
 
 - name: Set snmpd default settings
-  copy: src=files/etc/snmpd.default dest=/etc/default/snmpd owner=root group=root mode="0640"
+  ansible.builtin.copy:
+    src: files/etc/snmpd.default
+    dest: /etc/default/snmpd
+    owner: root
+    group: root
+    mode: "0640"
   tags: ['net-snmp']
 
 - name: Copy the snmpd.conf template file
-  template: src=snmpd.conf.j2 dest=/etc/snmp/snmpd.conf mode=0640
+  ansible.builtin.template:
+    src: snmpd.conf.j2
+    dest: /etc/snmp/snmpd.conf
+    mode: "0640"
   notify:
     - restart snmpd
   tags: ['net-snmp']
 
 - name: Enable disk monitoring
-  template: src=disk.conf.j2 dest={{ snmpd_include_dir }}/disk.conf mode=0640
+  ansible.builtin.template:
+    src: disk.conf.j2
+    dest: "{{ snmpd_include_dir }}/disk.conf"
+    mode: "0640"
   notify:
     - restart snmpd
   tags: ['net-snmp']
 
 - name: Enable process monitoring
-  template: src=proc.conf.j2 dest={{ snmpd_include_dir }}/proc.conf mode=0640
+  ansible.builtin.template:
+    src: proc.conf.j2
+    dest: "{{ snmpd_include_dir }}/proc.conf"
+    mode: "0640"
   notify:
     - restart snmpd
   tags: ['net-snmp']
 
 - name: Copy the Trap Inform template file
-  template: src=inform.conf.j2 dest={{ snmpd_include_dir }}/inform.conf mode=0640
+  ansible.builtin.template:
+    src: inform.conf.j2
+    dest: "{{ snmpd_include_dir }}/inform.conf"
+    mode: "0640"
   notify:
     - restart snmpd
   tags: ['net-snmp']
 
 - name: Copy the sysinfo inform template file
-  template: src=sysinfo.conf.j2 dest={{ snmpd_include_dir }}/sysinfo.conf mode=0640
+  ansible.builtin.template:
+    src: sysinfo.conf.j2
+    dest: "{{ snmpd_include_dir }}/sysinfo.conf"
+    mode: "0640"
   notify:
     - restart snmpd
   tags: ['net-snmp']

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,5 +1,14 @@
 # file: site.yml
 
-- import_playbook: 01-webserver.yml
-- import_playbook: 02-net-snmp.yml
-- import_playbook: 99-horizon-provision.yml
+- name: Deploy web server
+  import_playbook: 01-webserver.yml
+
+- name: Deploy Net-SNMP agents
+  import_playbook: 02-net-snmp.yml
+
+- name: Provision Switches into OpenNMS Horizon
+  import_playbook: 03-switches.yml
+
+- name: Provision OpenNMS Horizon
+  import_playbook: 99-horizon-provision.yml
+

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -11,4 +11,3 @@
 
 - name: Provision OpenNMS Horizon
   import_playbook: 99-horizon-provision.yml
-


### PR DESCRIPTION
Instead of running tasks in the playbook, I've added a conditional to run the import requisition node with the last node in the play for all hosts in a group. The requisition import task is also tagged and can be skipped with `--extra-vars '{"skip_import":"true"}'`

Resolves: #60