### PR TITLE
✨ feat: Allow to skip requisition import

### DIFF
--- a/ansible/01-webserver.yml
+++ b/ansible/01-webserver.yml
@@ -1,7 +1,8 @@
 ---
 # file: 01-webserver.yml
 
-- hosts: webserver
+- name: Group of web server
+  hosts: webserver
   become: true
   roles:
     - apache2

--- a/ansible/02-net-snmp.yml
+++ b/ansible/02-net-snmp.yml
@@ -1,7 +1,8 @@
 ---
 # file: 02-net-snmp.yml
 
-- hosts: all
+- name: Group of Servers with Net-SNMP agents
+  hosts: all
   become: true
   roles:
     - net-snmp

--- a/ansible/03-switches.yml
+++ b/ansible/03-switches.yml
@@ -1,7 +1,8 @@
 ---
 # file: horizon-provision.yaml
 
-- hosts: switches
+- name: Group of switches not managed with Ansible
+  hosts: switches
   gather_facts: false
   become: false
   roles:

--- a/ansible/99-horizon-provision.yml
+++ b/ansible/99-horizon-provision.yml
@@ -1,7 +1,8 @@
 ---
 # file: horizon-provision.yaml
 
-- hosts: monitoring
+- name: Group of hosts provisioned into OpenNMS Horizon
+  hosts: monitoring
   gather_facts: true
   become: true
   roles:

--- a/ansible/99-horizon-provision.yml
+++ b/ansible/99-horizon-provision.yml
@@ -6,13 +6,3 @@
   become: true
   roles:
     - horizon-provision
-  tasks:
-    - name: "Import requisitions"
-      ansible.builtin.uri:
-        url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/import?rescanExisting=true"
-        user: "{{ onms_hzn_user }}"
-        password: "{{ onms_hzn_password }}"
-        method: PUT
-        status_code: 202
-        headers:
-          Content-Type: "application/xml"

--- a/ansible/roles/apache2/tasks/main.yml
+++ b/ansible/roles/apache2/tasks/main.yml
@@ -1,21 +1,25 @@
 ---
 - name: "Install Apache2"
-  apt: name=apache2 update_cache=yes state=present
+  ansible.builtin.apt:
+    name=apache2 update_cache=yes state=present
 
 - name: "Enabled mod_rewrite"
-  apache2_module: name=rewrite state=present
+  community.general.apache2_module:
+    name=rewrite state=present
   notify:
-    - restart apache2
+    - Restart apache2
 
 - name: "Apache2 listen"
-  lineinfile: dest=/etc/apache2/ports.conf regexp="^Listen.*" line="Listen {{ http_port }}" state=present
+  ansible.builtin.lineinfile:
+    dest=/etc/apache2/ports.conf regexp="^Listen.*" line="Listen {{ http_port }}" state=present
   notify:
-    - restart apache2
+    - Restart apache2
 
 - name: "Apache2 virtualhost"
-  lineinfile: dest=/etc/apache2/sites-available/000-default.conf regexp="^<VirtualHost \*:.*>" line="<VirtualHost *:{{ http_port }}>" state=present
+  ansible.builtin.lineinfile:
+    dest=/etc/apache2/sites-available/000-default.conf regexp="^<VirtualHost \*:.*>" line="<VirtualHost *:{{ http_port }}>" state=present
   notify:
-    - restart apache2
+    - Restart apache2
 
 - name: "Start service Apache2"
   ansible.builtin.service:

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -10,6 +10,8 @@
   ignore_errors: true
   no_log: true
   register: requisition_exists
+  tags:
+    - opennms-provisioning
 
 - name: "Create requisitions"
   ansible.builtin.uri:
@@ -24,6 +26,8 @@
   no_log: true
   register: requisition_created
   when: requisition_exists.failed
+  tags:
+    - opennms-provisioning
 
 - name: "Create policies and detectors for requisitions (foreign-sources)"
   ansible.builtin.uri:
@@ -38,6 +42,8 @@
   no_log: true
   register: requisition_created
   when: requisition_exists
+  tags:
+    - opennms-provisioning
 
 - name: "Verify if nodes exist in requisitions"
   ansible.builtin.uri:
@@ -51,6 +57,8 @@
   no_log: true
   register: node_exists
   when: requisition_exists
+  tags:
+    - opennms-provisioning
 
 - name: "Create nodes in requisitions"
   ansible.builtin.uri:
@@ -65,6 +73,8 @@
   no_log: false
   register: node_created
   when: node_exists.failed
+  tags:
+    - opennms-provisioning
 
 - name: "Verify if monitored services exists"
   ansible.builtin.uri:
@@ -80,6 +90,8 @@
   register: service_exists
   when: node_exists
   with_items: "{{ onms_group_services | combine(onms_host_services) }}"
+  tags:
+    - opennms-provisioning
 
 - name: "Create monitored services"
   ansible.builtin.uri:
@@ -97,7 +109,13 @@
   register: service_created
   when: service_exists.failed
   with_dict: "{{ onms_group_services | combine(onms_host_services) }}"
+  tags:
+    - opennms-provisioning
 
+# ansible_play-hosts:
+# List of hosts in the current play run, not limited by the serial. Failed/Unreachable hosts are excluded from this list.
+# With the condition inventory_hostname == ansible_play_hosts[-1] we run the task only for the last host in the current play
+# and ensures we run this task only once per group
 - name: "Import requisitions"
   ansible.builtin.uri:
     url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/import?rescanExisting=true"
@@ -109,3 +127,6 @@
       Content-Type: "application/xml"
   when:
     - skip_import | default("false") == "false"
+  tags:
+    - opennms-provisioning
+    - opennms-requisition-import

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -97,3 +97,15 @@
   register: service_created
   when: service_exists.failed
   with_dict: "{{ onms_group_services | combine(onms_host_services) }}"
+
+- name: "Import requisitions"
+  ansible.builtin.uri:
+    url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/import?rescanExisting=true"
+    user: "{{ onms_hzn_user }}"
+    password: "{{ onms_hzn_password }}"
+    method: PUT
+    status_code: 202
+    headers:
+      Content-Type: "application/xml"
+  when:
+    - skip_import | default("false") == "false"

--- a/ansible/roles/net-snmp/handlers/main.yml
+++ b/ansible/roles/net-snmp/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
-- name: restart snmpd
-  service: name=snmpd state=restarted
+- name: Restart snmpd
+  ansible.builtin.service:
+    name=snmpd state=restarted

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,5 +1,14 @@
 # file: site.yml
 
-- import_playbook: 01-webserver.yml
-- import_playbook: 02-net-snmp.yml
-- import_playbook: 99-horizon-provision.yml
+- name: Deploy web server
+  import_playbook: 01-webserver.yml
+
+- name: Deploy Net-SNMP agents
+  import_playbook: 02-net-snmp.yml
+
+- name: Provision Switches into OpenNMS Horizon
+  import_playbook: 03-switches.yml
+
+- name: Provision OpenNMS Horizon
+  import_playbook: 99-horizon-provision.yml
+


### PR DESCRIPTION
If you create very large requisitions, we give the user the ability to skip the import and let him do some sanitychecks before he is going to synchronize the nodes in the requisition.

The variable skip_import is introduced and by default set to false. If the user wants to skip the import of the requisition he should set `-e skip_import=true`.