### PR TITLE
Some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Example:
 onms_requisition_name: switches
 ```
 
-`onms_policies` can create [provisioning policies](https://docs.opennms.com/horizon/latest/reference/provisioning/policies.html) to requistions.
+`onms_policies` can create [provisioning policies](https://docs.opennms.com/horizon/latest/reference/provisioning/policies.html) to requisitions.
 
 Examples:
 ```
@@ -194,4 +194,11 @@ onms_host_services:
    HTTPS: {}
 ```
 
+`skip_import` can be used to control, whether the requisition gets imported or not
 
+Example:
+
+The default is `false` to always import.
+```
+ansible-playbook -i inventory site.yml --extra-vars '{"skip_import":"true"}'
+```

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -62,7 +62,7 @@
     headers:
       Content-Type: "application/xml"
     body: "{{ lookup('template', 'node_xml.j2') }}"
-  no_log: false
+  no_log: true
   register: node_created
   when: node_exists.failed
 

--- a/ansible/roles/horizon-provision/templates/node_xml.j2
+++ b/ansible/roles/horizon-provision/templates/node_xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- {{ ansible_managed }} -->
-<node location="{{ onms_location }}" building="{{ onms_requisition_name }}" foreign-id="{{ onms_host_foreignid }}" node-label="{{ onms_host_nodelabel }}">
+<node location="{{ onms_location }}" foreign-id="{{ onms_host_foreignid }}" node-label="{{ onms_host_nodelabel }}">
   <interface descr="disc-if" ip-addr="{{ ansible_host }}" managed="true" status="1" snmp-primary="P"/>
 
   {% if onms_host_categories is defined %}
@@ -36,7 +36,7 @@
 
   {% if onms_host_metadata is defined %}
     {% for k, v in onms_host_metadata.items() %}
-    <meta-data context="requistion" key="{{ k }}" value="{{ v }}"/>
+    <meta-data context="requisition" key="{{ k }}" value="{{ v }}"/>
     {% endfor %}
   {% endif %}
 </node>


### PR DESCRIPTION
* fixed 2 `requisition` typos
* Added the `skip-import` parameter in the README
* set one task to `no_log` (I guess we forgot that in another PR)
* removed the `building` parameter in the node template (since we don't have to set this)

@indigo423 FYI