### PR TITLE
:rocket::rocket::rocket: #78 Add additional interface support

### DIFF
--- a/ansible/inventory/03-switches.yml
+++ b/ansible/inventory/03-switches.yml
@@ -4,15 +4,15 @@ switches:
     switch1:
       ansible_host: 172.16.238.14
       additional_nic:
-            "172.16.238.20":
-                ICMP:
-                  retry: 5
-                  timeout: 10
-                HTTP:
-                  port: 80
-            "172.16.238.21":
-                SNMP:
-                  retry: 5
-                  timeout: 10
+        "172.16.238.20":
+          ICMP:
+            retry: 5
+            timeout: 10
+          HTTP:
+            port: 80
+        "172.16.238.21":
+          SNMP:
+            retry: 5
+            timeout: 10
     switch2:
       ansible_host: 172.16.238.15

--- a/ansible/inventory/03-switches.yml
+++ b/ansible/inventory/03-switches.yml
@@ -3,5 +3,16 @@ switches:
   hosts:
     switch1:
       ansible_host: 172.16.238.14
+      additional_nic:
+            "172.16.238.20":
+                ICMP:
+                  retry: 5
+                  timeout: 10
+                HTTP:
+                  port: 80
+            "172.16.238.21":
+                SNMP:
+                  retry: 5
+                  timeout: 10
     switch2:
       ansible_host: 172.16.238.15

--- a/ansible/roles/horizon-provision/templates/node_xml.j2
+++ b/ansible/roles/horizon-provision/templates/node_xml.j2
@@ -11,6 +11,19 @@
 {% endfor %}
 {% endif %}
   </interface>
+{% if additional_nic is defined %}
+{% for key,item in additional_nic.items() %}
+  <interface ip-addr="{{ key }}" snmp-primary="N">
+{% for key,item in item.items() %}
+    <monitored-service service-name="{{ key }}">
+{% for k,v in item.items() %}
+      <meta-data context="requisition" key="{{ k }}" value="{{ v }}"/>
+{% endfor %}
+    </monitored-service>
+{% endfor %}
+  </interface>
+{% endfor %}
+{% endif %}
 {% if onms_host_categories is defined %}
 {% for category in onms_host_categories %}
   <category name="{{ category }}"/>


### PR DESCRIPTION
fix #78

I am adding here in the switch inventory an dictionary `additional_nic` definition with IPs, their services and metadata. The node templates is changed to add those interfaces accordingly.
The definition of `switch1` looks now like:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<node xmlns="http://xmlns.opennms.org/xsd/config/model-import" location="Default" foreign-id="switch1" node-label="switch1" parent-foreign-id="200">
  <interface descr="disc-if" ip-addr="172.16.238.14" managed="true" status="1" snmp-primary="P">
    <monitored-service service-name="ICMP">
    </monitored-service>
  </interface>
  <interface ip-addr="172.16.238.20" snmp-primary="N">
    <monitored-service service-name="ICMP">
      <meta-data context="requisition" key="retry" value="5"/>
      <meta-data context="requisition" key="timeout" value="10"/>
    </monitored-service>
    <monitored-service service-name="HTTP">
      <meta-data context="requisition" key="port" value="80"/>
    </monitored-service>
  </interface>
  <interface ip-addr="172.16.238.21" snmp-primary="N">
    <monitored-service service-name="SNMP">
      <meta-data context="requisition" key="retry" value="5"/>
      <meta-data context="requisition" key="timeout" value="10"/>
    </monitored-service>
  </interface>
  <asset name="description" value="switch"/>
  <asset name="floor" value="2"/>
  <asset name="room" value="213"/>
  <asset name="rack" value="1"/>
  <asset name="rackunitheight" value="1"/>
  <meta-data context="requisition" key="env" value="prod"/>
  <meta-data context="requisition" key="app" value="switches"/>
</node>
```