### PR TITLE
Some minor performance improvements

### DIFF
--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -54,7 +54,7 @@
       Content-Type: "application/xml"
     body: "{{ lookup('template', 'foreignSources_xml.j2') }}"
   no_log: true
-  register: foreign-source_created
+  register: foreignsource_created
   when: requisition_created.changed
   tags:
     - opennms-provisioning

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -85,7 +85,7 @@
     headers:
       Content-Type: "application/xml"
     body: "{{ lookup('template', 'node_xml.j2') }}"
-  no_log: false
+  no_log: true
   tags:
     - opennms-provisioning
   when: node_exists.failed

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -54,7 +54,6 @@
       Content-Type: "application/xml"
     body: "{{ lookup('template', 'foreignSources_xml.j2') }}"
   no_log: true
-  register: foreignsource_created
   when: requisition_created.changed
   tags:
     - opennms-provisioning

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -24,6 +24,7 @@
   tags:
     - opennms-provisioning
   delegate_to: localhost
+  run_once: True
 
 - name: "Create requisitions"
   ansible.builtin.uri:
@@ -54,7 +55,7 @@
     body: "{{ lookup('template', 'foreignSources_xml.j2') }}"
   no_log: true
   register: requisition_created
-  when: requisition_exists
+  when: requisition_created.changed
   tags:
     - opennms-provisioning
   delegate_to: localhost

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -24,7 +24,7 @@
   tags:
     - opennms-provisioning
   delegate_to: localhost
-  run_once: True
+  run_once: true
 
 - name: "Create requisitions"
   ansible.builtin.uri:
@@ -54,7 +54,7 @@
       Content-Type: "application/xml"
     body: "{{ lookup('template', 'foreignSources_xml.j2') }}"
   no_log: true
-  register: requisition_created
+  register: foreign-source_created
   when: requisition_created.changed
   tags:
     - opennms-provisioning


### PR DESCRIPTION
Running the requisition exist check only ones per inventory (`run_once`). Right now, this is ok, since the concept is to add an amount of node into one requisition. This needs to be changed if the we want to go another way.
The changed trigger for creating `foreign-sources` is improved to only run when the requisition was created.
Both changed reduce heavily the amount of API calls.