### PR TITLE
#95 Add PUT call

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -173,6 +173,14 @@ The removal API calls are `never` called by default. They can be run by using th
 ```
 ansible-playbook -i inventory/03-switches.yml 03-switches.yml -l switch1 --tags opennms-node-removal
 ```
+### Update node information
+
+To overwrite existing node data, the tag `opennms-node-update` can be used.
+Please be aware that removing data is currently only possible by deleting the node.
+
+```
+ansible-playbook -i inventory/03-switches.yml 03-switches.yml -l switch1 --tags opennms-node-update
+```
 
 ### skip_import
 

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -59,24 +59,7 @@
     - opennms-provisioning
   delegate_to: localhost
 
-- name: "Verify if nodes exist in requisitions"
-  ansible.builtin.uri:
-    url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/nodes/{{ onms_host_foreignid }}"
-    user: "{{ onms_hzn_user }}"
-    password: "{{ onms_hzn_password }}"
-    method: GET
-    force_basic_auth: true
-    status_code: 200
-  ignore_errors: true
-  no_log: true
-  register: node_exists
-  when: requisition_exists
-  tags:
-    - opennms-provisioning
-    - opennms-node-update
-  delegate_to: localhost
-
-- name: "Create nodes in requisitions"
+- name: "Create or update nodes in requisitions"
   ansible.builtin.uri:
     url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/nodes"
     user: "{{ onms_hzn_user }}"
@@ -89,26 +72,8 @@
   no_log: false
   tags:
     - opennms-provisioning
-  when: node_exists.failed
-  delegate_to: localhost
-
-- name: "Update nodes in requisitions"
-  ansible.builtin.uri:
-    url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/nodes/{{ onms_host_foreignid }}"
-    user: "{{ onms_hzn_user }}"
-    password: "{{ onms_hzn_password }}"
-    method: PUT
-    status_code: 202
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
-    body: "{{ lookup('template', 'node_xml.j2') }}"
-  no_log: false
-  tags:
-    - never
     - opennms-node-update
-  when: node_exists.failed
   delegate_to: localhost
-
 
 # Creates a file in the root folder and writes the node definition into it.
 # This is helpful if you want to change the node_xml.j2 and see the exact output.

--- a/ansible/roles/horizon-provision/tasks/main.yml
+++ b/ansible/roles/horizon-provision/tasks/main.yml
@@ -73,6 +73,7 @@
   when: requisition_exists
   tags:
     - opennms-provisioning
+    - opennms-node-update
   delegate_to: localhost
 
 - name: "Create nodes in requisitions"
@@ -90,6 +91,24 @@
     - opennms-provisioning
   when: node_exists.failed
   delegate_to: localhost
+
+- name: "Update nodes in requisitions"
+  ansible.builtin.uri:
+    url: "{{ onms_hzn_base_rest_url }}/{{ onms_hzn_requisitions_api }}/{{ onms_requisition_name }}/nodes/{{ onms_host_foreignid }}"
+    user: "{{ onms_hzn_user }}"
+    password: "{{ onms_hzn_password }}"
+    method: PUT
+    status_code: 202
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    body: "{{ lookup('template', 'node_xml.j2') }}"
+  no_log: false
+  tags:
+    - never
+    - opennms-node-update
+  when: node_exists.failed
+  delegate_to: localhost
+
 
 # Creates a file in the root folder and writes the node definition into it.
 # This is helpful if you want to change the node_xml.j2 and see the exact output.
@@ -122,4 +141,5 @@
     - opennms-provisioning
     - opennms-requisition-import
     - opennms-node-removal
+    - opennms-node-update
   delegate_to: localhost


### PR DESCRIPTION
fix #95 

It looks great. But it does not work, yet. The playbook runs smoothly without complaining. But the data are not update in the requisition.

This can be tested easily by adding the switches:

`ansible-playbook -i inventory/03-switches.yml 03-switches.yml`

change an asset or something else and run

`ansible-playbook -i inventory/03-switches.yml 03-switches.yml --tags opennms-node-update`